### PR TITLE
feat: udpate caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@fastify/one-line-logger": "2.0.2",
         "@fastify/react": "1.1.0",
         "@fastify/vite": "8.1.3",
+        "@isaacs/ttlcache": "1.4.1",
         "@mui/icons-material": "6.4.11",
         "@mui/material": "6.4.11",
         "@unhead/react": "2.0.9",
@@ -2048,6 +2049,15 @@
         "wrap-ansi": "^8.1.0",
         "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@unhead/react": "2.0.9",
         "aos": "2.3.4",
         "fastify": "5.3.3",
-        "lru-cache": "11.1.0",
         "react": "19.1.0",
         "react-dom": "19.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@unhead/react": "2.0.9",
     "aos": "2.3.4",
     "fastify": "5.3.3",
-    "lru-cache": "11.1.0",
     "react": "19.1.0",
     "react-dom": "19.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@fastify/one-line-logger": "2.0.2",
     "@fastify/react": "1.1.0",
     "@fastify/vite": "8.1.3",
+    "@isaacs/ttlcache": "1.4.1",
     "@mui/icons-material": "6.4.11",
     "@mui/material": "6.4.11",
     "@unhead/react": "2.0.9",


### PR DESCRIPTION
This work updates the caching from using LRU _(least recently used)_ to TTL _(time to live)_ caching. This will allow items to have a lifetime in cache, rather than existing until they get moved out.