### PR TITLE
feat: refactor caching/fetching strategy

### DIFF
--- a/client/components/PhotoGrid.jsx
+++ b/client/components/PhotoGrid.jsx
@@ -40,15 +40,16 @@ const Overlay = ({ photo }) => {
 };
 
 export default function PhotoGrid() {
-  const { state, data, domain } = useRouteContext();
+  // INFO: snapshot is a version of `state`
+  const { snapshot, data, domain } = useRouteContext();
   const [selectedCollection, setSelectedCollection] = useState("all");
 
   const collection = useMemo(() => {
     switch (selectedCollection) {
       case "all":
-        return state.all;
+        return snapshot.all;
       default:
-        return state.groups[selectedCollection];
+        return snapshot.groups[selectedCollection];
     }
   }, [selectedCollection]);
 
@@ -83,7 +84,7 @@ export default function PhotoGrid() {
     <Box>
       <Container paddingY="" sx={{ paddingBottom: { xs: 4, sm: 6, md: 8 } }}>
         <Collections
-          collections={["all", ...Object.keys(state.groups)]}
+          collections={["all", ...Object.keys(snapshot.groups)]}
           onChange={(value) => {
             setSelectedCollection(value);
           }}

--- a/client/pages/index.jsx
+++ b/client/pages/index.jsx
@@ -33,7 +33,7 @@ export async function getData(ctx) {
       for (const item of ctx.state.all) {
         const value = cache.get(item.name);
         if (value) {
-          log.info(`cache hit: ${item.name}`);
+          log.debug(`cache hit: ${item.name}`);
           data[item.name] = value;
         } else {
           log.warn(`cache miss: ${item.name}`);

--- a/client/pages/index.jsx
+++ b/client/pages/index.jsx
@@ -10,7 +10,6 @@ import PhotoGrid from "../components/PhotoGrid";
 import { useRouteContext } from "@fastify/react/client";
 import { useTheme } from "@mui/material/styles";
 
-import { GetObjectCommand } from "@aws-sdk/client-s3";
 import { Suspense } from "react";
 
 // INFO: can't use `serverOnly=true` because then the scroll to lazy load images
@@ -23,38 +22,24 @@ export const streaming = true;
 
 export async function getData(ctx) {
   if (ctx.server) {
-    const { log } = ctx.server;
+    const { log, cache } = ctx.server;
     log.info({ "ctx.server": !!ctx.server }, "pages/index.jsx::getData");
 
     if (ctx.state.all) {
       const data = {};
 
       for (const item of ctx.state.all) {
-        try {
-          const value = ctx.server.cache.get(item.name);
-          if (value) {
-            log.info(`cache hit: ${item.name}`);
-            data[item.name] = value;
-          } else {
-            log.warn(`cache miss: ${item.name}`);
-            const bucket = ctx.server.getEnvs().DO_SPACE_BUCKET;
-            const command = new GetObjectCommand({
-              Bucket: bucket,
-              Key: item.name,
-            });
-            const response = await ctx.server.s3Client.send(command);
+        const value = cache.get(item.name);
+        if (value) {
+          log.info(`cache hit: ${item.name}`);
+          data[item.name] = value;
+        } else {
+          log.warn(`cache miss: ${item.name}`);
 
-            const { Metadata } = response;
-
-            const { title = "Image Title", description = "Image Description" } =
-              Metadata;
-
-            ctx.server.cache.set(item.name, { title, description });
-            data[item.name] = { title, description };
-          }
-        } catch (err) {
-          log.error({ err }, err.message);
-          throw err;
+          data[item.name] = {
+            title: "Image Title",
+            description: "Image Description",
+          };
         }
       }
 
@@ -92,7 +77,7 @@ export default function Index() {
 
   return (
     <main>
-      <Hero url={`https://cdn.${domain}/_hero-header.jpg`} />
+      <Hero url={`https://cdn.${domain}/_hero-header-min.jpg`} />
       <Container>
         <Suspense fallback={<p>Loading...</p>}>
           <PhotoGrid />

--- a/client/pages/index.jsx
+++ b/client/pages/index.jsx
@@ -25,6 +25,8 @@ export async function getData(ctx) {
     const { log, cache } = ctx.server;
     log.info({ "ctx.server": !!ctx.server }, "pages/index.jsx::getData");
 
+    // INFO: context executes first, populating `ctx.state.all`
+    // https://fastify-vite.dev/react/route-context#execution-order
     if (ctx.state.all) {
       const data = {};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@unhead/react": "2.0.9",
         "aos": "2.3.4",
         "fastify": "5.3.3",
+        "fastify-plugin": "5.0.1",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-intersection-observer": "9.16.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "npm run start -- --dev",
     "build": "vite build",
     "preview": "npm run build && npm run start",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@unhead/react": "2.0.9",
     "aos": "2.3.4",
     "fastify": "5.3.3",
+    "fastify-plugin": "5.0.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-intersection-observer": "9.16.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "node server.js",
     "dev": "npm run start -- --dev",
     "build": "vite build",
-    "preview": "npm run build && npm run start",
+    "preview": "npm run build && npm run start | pino-pretty",
     "test": "node --test"
   },
   "repository": {

--- a/server.js
+++ b/server.js
@@ -1,9 +1,11 @@
 import Fastify from "fastify";
 import FastifyVite from "@fastify/vite";
 import FastifyEnv from "@fastify/env";
-import TTLCache from "@isaacs/ttlcache";
 
-import { S3 } from "@aws-sdk/client-s3";
+import PluginCache from "./utils/plugin-cache.js";
+import PluginSpaceAccess from "./utils/plugin-space-access.js";
+
+import createGroups from "./utils/util-createGroups.js";
 
 const server = Fastify({
   logger: process.argv.includes("--dev")
@@ -44,34 +46,41 @@ await server.register(FastifyEnv, {
   },
 });
 
-// INFO: decorate with s3client
-const s3Client = new S3({
-  forcePathStyle: false,
+await server.register(PluginCache, {
+  ttl: 60 * 60 * 1_000 * 72, // 72 hours
+});
+
+// INFO: must be registered *after* `PluginCache`
+await server.register(PluginSpaceAccess, {
   endpoint: "https://tor1.digitaloceanspaces.com",
   region: "tor1",
-  credentials: {
-    accessKeyId: server.getEnvs().DO_SPACE_ACCESS_KEY_ID,
-    secretAccessKey: server.getEnvs().DO_SPACE_SECRET_KEY,
+  accessKeyId: server.getEnvs().DO_SPACE_ACCESS_KEY_ID,
+  secretAccessKey: server.getEnvs().DO_SPACE_SECRET_KEY,
+  bucket: server.getEnvs().DO_SPACE_BUCKET,
+
+  // INFO: need `function` declaration because need access to `this`
+  hydrateCache: async function hydrate() {
+    // INFO: `this` context: SpaceAccess class instance
+    const objects = await this.listObjects();
+
+    if (objects && objects.length) {
+      const groups = createGroups(objects);
+
+      const groupsCacheKey = "image:groups";
+      this.fastify.cache.set(groupsCacheKey, groups);
+
+      for (const [key, value] of Object.entries(groups)) {
+        const cacheKey = `image:group:${key}`;
+        this.fastify.cache.set(cacheKey, value);
+        this.cacheGroupKey.add(cacheKey);
+      }
+
+      for (const item of groups.all) {
+        await this.getObject(item.name);
+      }
+    }
   },
 });
-
-if (!server.s3Client) {
-  server.decorate("s3Client", s3Client);
-}
-
-// INFO: decorate with cache
-const cache = new TTLCache({
-  max: 200,
-  ttl: 1 * 60 * 60 * 1_000, // one hour
-  updateAgeOnGet: true,
-  dispose(_value, key, reason) {
-    server.log.info(`cache:dispose - ${key} - ${reason}`);
-  },
-});
-
-if (!server.cache) {
-  server.decorate("cache", cache);
-}
 
 await server.register(FastifyVite, {
   root: import.meta.dirname, // where to look for vite.config.js
@@ -79,7 +88,11 @@ await server.register(FastifyVite, {
   renderer: "@fastify/react",
 });
 
+// INFO: initialise vite
 await server.vite.ready();
+
+// INFO: hydrate cache
+await server.space.hydrate();
 
 server.get("/healthcheck", async (_req, reply) => {
   try {

--- a/utils/plugin-cache.js
+++ b/utils/plugin-cache.js
@@ -1,10 +1,15 @@
+import { EventEmitter } from "node:events";
 import fp from "fastify-plugin";
 import TTLCache from "@isaacs/ttlcache";
 
 // INFO: Cache Plugin
-class Cache {
+class Cache extends EventEmitter {
   constructor(options) {
+    super();
     const { log, ...cacheOptions } = options;
+
+    // INFO: required because of context switching below
+    const self = this;
 
     // INFO: set logger to use
     this.log = log;
@@ -12,19 +17,29 @@ class Cache {
     // INFO: create cache instance
     this.cache = new TTLCache({
       ttl: 60 * 60 * 1_000 * 1, // one hour
-      updateAgeOnGet: true,
-      dispose(value, key, reason) {
-        this.log.info({ value, key, reason }, `cache:displose - ${key}`);
+      dispose(_value, key, reason) {
+        self.log.info(
+          { key, reason, cacheSize: self.cache.size },
+          `cache:displose - ${key} - ${reason}`,
+        );
+
+        if (self.cache.size === 0) {
+          self.emit("cache:invalidation", {
+            cacheSize: self.cache.size,
+          });
+        }
       },
       ...cacheOptions,
     });
   }
 
   set(key, value) {
+    this.log.debug({ key }, "setting key");
     return this.cache.set(key, value);
   }
 
   get(key) {
+    this.log.debug({ key }, "getting key");
     return this.cache.get(key);
   }
 }

--- a/utils/plugin-cache.js
+++ b/utils/plugin-cache.js
@@ -1,0 +1,49 @@
+import fp from "fastify-plugin";
+import TTLCache from "@isaacs/ttlcache";
+
+// INFO: Cache Plugin
+class Cache {
+  constructor(options) {
+    const { log, ...cacheOptions } = options;
+
+    // INFO: set logger to use
+    this.log = log;
+
+    // INFO: create cache instance
+    this.cache = new TTLCache({
+      ttl: 60 * 60 * 1_000 * 1, // one hour
+      updateAgeOnGet: true,
+      dispose(value, key, reason) {
+        this.log.info({ value, key, reason }, `cache:displose - ${key}`);
+      },
+      ...cacheOptions,
+    });
+  }
+
+  set(key, value) {
+    return this.cache.set(key, value);
+  }
+
+  get(key) {
+    return this.cache.get(key);
+  }
+}
+
+function plugin(fastify, options, done) {
+  fastify.decorate(
+    "cache",
+    new Cache({
+      ...options,
+      log: fastify.log.child({ log_type: "plugin:cache" }),
+    }),
+  );
+
+  done();
+}
+
+const pluginCache = fp(plugin, {
+  fastify: "5.x",
+  name: "plugin-ttlcache",
+});
+
+export default pluginCache;

--- a/utils/plugin-space-access.js
+++ b/utils/plugin-space-access.js
@@ -1,0 +1,124 @@
+import fp from "fastify-plugin";
+import { S3, ListObjectsV2Command, GetObjectCommand } from "@aws-sdk/client-s3";
+
+class PluginSpaceAccessError extends Error {
+  constructor(message, options) {
+    super(message, options);
+  }
+}
+
+class SpaceAccess {
+  constructor(fastify, options) {
+    const {
+      log,
+      hydrateCache,
+      endpoint,
+      region,
+      accessKeyId,
+      secretAccessKey,
+    } = options;
+
+    this.fastify = fastify;
+
+    // INFO: shallow clone options
+    this.options = { ...options };
+
+    // INFO: set logger to use
+    this.log = log;
+
+    // INFO: create client instance
+    this.client = new S3({
+      forcePathStyle: false,
+      endpoint,
+      region,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+      },
+    });
+
+    // INFO: set hydrate function
+    this.hydrateCache = hydrateCache;
+
+    this.cacheGroupKey = new Set();
+  }
+
+  // INFO: expose hydrate function
+  async hydrate(...args) {
+    try {
+      this.log.info({}, "hydrating cache started");
+      await this.hydrateCache(...args);
+      this.log.info({}, "hydrating cache completed");
+    } catch (err) {
+      const msg = "failed to hydrate cache";
+      this.log.info({ err }, msg);
+      throw new PluginSpaceAccessError(msg, { cause: err });
+    }
+  }
+
+  async listObjects() {
+    try {
+      const command = new ListObjectsV2Command({
+        Bucket: this.options.bucket,
+      });
+      const response = await this.client.send(command);
+      const { Contents } = response;
+
+      // INFO: cache value
+      this.fastify.cache.set("", Contents);
+
+      return Contents;
+    } catch (err) {
+      const msg = "failed to list objects";
+      this.log.error({ err }, msg);
+      throw new PluginSpaceAccessError(msg, { cause: err });
+    }
+  }
+
+  async getObject(key) {
+    try {
+      const command = new GetObjectCommand({
+        Bucket: this.options.bucket,
+        Key: key,
+      });
+      const response = await this.client.send(command);
+      const { Metadata } = response;
+      const { title = "Image Title", description = "Image Description" } =
+        Metadata;
+
+      const value = { title, description };
+
+      // INFO: cache value
+      this.fastify.cache.set(key, value);
+
+      return value;
+    } catch (err) {
+      const msg = `failed to get object for key: ${key}`;
+      this.log.error({ err }, msg);
+      throw new PluginSpaceAccessError(msg, { cause: err });
+    }
+  }
+}
+
+function plugin(fastify, options, done) {
+  fastify.decorate(
+    "space",
+    new SpaceAccess(fastify, {
+      ...options,
+      log: fastify.log.child({ log_type: "plugin:space-access" }),
+    }),
+  );
+
+  done();
+}
+
+const pluginSpaceAccess = fp(plugin, {
+  fastify: "5.x",
+  name: "plugin-space-access",
+  decorators: {
+    fastify: ["cache"],
+  },
+  dependencies: ["plugin-ttlcache"],
+});
+
+export default pluginSpaceAccess;

--- a/utils/util-createGroups.js
+++ b/utils/util-createGroups.js
@@ -1,0 +1,74 @@
+/**
+ * @typedef {Object} ObjectItem
+ * @property {string} Key - Filename of the object
+ * @property {string} ETag - Unique identifier for object
+ */
+
+/**
+ * @typedef {Object} GroupedObjects
+ * @property {ObjectItem[]} all - All objects grouped
+ * @property {ObjectItem[]} general  - All objects grouped
+ */
+
+/**
+ * Creates object with grouped values
+ * @param {ObjectItem[]} objects - List of objects to group
+ * @returns {GroupedObjects} Grouped objects
+ */
+export default function createGroups(objects = []) {
+  const ALL = "all";
+  const GENERAL = "general";
+
+  return objects.reduce((acc, object) => {
+    const parts = object.Key.split("/");
+
+    // TODO: figure out if there is a better way to do this double assign
+    const collection = parts[0];
+    const first = parts[0];
+    const last = parts[parts.length - 1];
+
+    const item = {
+      name: object.Key,
+      tag: object.ETag,
+    };
+
+    // INFO: if filename starts with underscore, skip it
+    if (first.startsWith("_")) {
+      return acc;
+    }
+
+    if (!acc[ALL]) {
+      acc[ALL] = [];
+    }
+
+    if (parts.length === 1) {
+      if (!acc[GENERAL]) {
+        acc[GENERAL] = [];
+      }
+
+      acc[GENERAL].push(item);
+      acc[ALL].push(item);
+      return acc;
+    }
+
+    // INFO: We will always receive an object for the folder. This object will
+    // have a `Key` value that ends with a `/` backslash. We _should_ always
+    // iterate this object before we iterate an object from inside that
+    // 'folder'.
+    if (Object.keys(acc).includes(collection)) {
+      acc[collection].push(item);
+      acc[ALL].push(item);
+      return acc;
+    }
+
+    if (!last) {
+      // INFO: last part is falsy
+      // create the collection
+      if (!acc[collection]) {
+        acc[collection] = [];
+      }
+    }
+
+    return acc;
+  }, {});
+}

--- a/utils/util-createGroups.test.js
+++ b/utils/util-createGroups.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import createGroups from "./util-createGroups.js";
+
+test("createGroups", async (t) => {
+  await t.test("should return object", async (t) => {
+    await t.test("if provided an empty array", async (t) => {
+      const actualResult = createGroups([]);
+      assert.equal(typeof actualResult, "object");
+    });
+
+    await t.test("if no argument passed", async (t) => {
+      const actualResult = createGroups();
+      assert.equal(typeof actualResult, "object");
+    });
+  });
+
+  await t.test("should create default groups", async (t) => {
+    const mockObjects = [
+      {
+        Key: "first",
+        ETag: "sometag",
+      },
+    ];
+    const actualResults = createGroups(mockObjects);
+    assert.ok(actualResults.all, "should create 'all' group");
+    assert.ok(actualResults.general, "should create 'general' group");
+    assert.equal(actualResults.all.length, 1);
+    assert.equal(actualResults.general.length, 1);
+  });
+
+  await t.test("should create groups based on Key parts", async (t) => {
+    const mockObjects = [
+      {
+        Key: "first.jpg",
+        ETag: "sometag",
+      },
+      {
+        Key: "blue/",
+        ETag: "sometag",
+      },
+      {
+        Key: "blue/one.jpg",
+        ETag: "sometag",
+      },
+    ];
+    const actualResults = createGroups(mockObjects);
+
+    console.log("actualResults:", actualResults);
+    assert.ok(actualResults.all, "should create 'all' group");
+    assert.ok(actualResults.general, "should create 'general' group");
+    assert.ok(actualResults.blue, "should create 'blue' group");
+    assert.equal(actualResults.all.length, 2);
+    assert.equal(actualResults.general.length, 1);
+    assert.equal(actualResults.blue.length, 1);
+  });
+});


### PR DESCRIPTION
- Refactored caching into it's own plugin
  - Extend `EventEmitter`
  - Emit an event when the cache is cleared _(`cache.size === 0`)_
- Refactored object access into it's own plugin
  - Add hydration state handling
- Refactored server to use these new plugins
  - Add event listener for cache invalidation
  - Rehydrate cache once it has been invalidated
- Add cache hydration when server starts
- Update server side rendering logic to only use cached values